### PR TITLE
return additional metadata for object list query

### DIFF
--- a/cos.js
+++ b/cos.js
@@ -954,8 +954,12 @@ module.exports = function(RED) {
 					for (x in data.Contents) {
 						var elem = {
 							Key: data.Contents[x].Key,
-							Size: data.Contents[x].Size
+							Size: data.Contents[x].Size,
+							LastModified: data.Contents[x].LastModified,
+							ETag: data.Contents[x].ETag,
+							StorageClass: data.Contents[x].StorageClass
 						};
+						// var elem = data.Contents[x];
 						retarr.push(elem);
 					}
 	


### PR DESCRIPTION
knowing lastmodified date/time is very useful for polling changes to bucket contents

(tagging  get/set support on public cloud would help even more, but not supported)