### PR TITLE
Fix presigned url output to msg.url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 20190626 updated cos.js. Output presign url on msg.url. Controlled geturl bool setting in node or value of msg,geturl.
+20190626 updated cos.js. Output presign url on msg.url. Controlled geturl bool setting in node or value of msg,geturl.
 
 # node-red-contrib-cos
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# 20190626 updated cos.js. Output presign url on msg.url. Controlled geturl bool setting in node or value of msg,geturl.
+
 # node-red-contrib-cos
 
 A <a href="http://nodered.org" target="_new">Node-RED</a> node to store, delete, restore and query objects from the

--- a/cos.js
+++ b/cos.js
@@ -220,7 +220,8 @@ module.exports = function(RED) {
 						} 
 
 						console.log("Cloud Object Storage Get (log): The URL is", url);
-						msg.url = url;	
+						msg.url = url;
+						node.send(msg);
 					});
 
 				}
@@ -229,7 +230,9 @@ module.exports = function(RED) {
 				node.status({fill:"green",shape:"ring",text:"cos.status.ready"});
 
 				// Send the output back 
-				node.send(msg);	
+				if (!geturl){
+					node.send(msg);
+				}
 			});
 		});
 
@@ -483,7 +486,8 @@ module.exports = function(RED) {
 							} 
 
 							console.log("Cloud Object Storage Put (log): The URL is", url);
-							msg.url = url;	
+							msg.url = url;
+							node.send(msg);
 						});
 
 					}
@@ -492,7 +496,9 @@ module.exports = function(RED) {
 					node.status({fill:"green",shape:"ring",text:"cos.status.ready"});
 
 					// Send the output back 
-					node.send(msg);
+					if (!geturl){
+						node.send(msg);
+					}
 				});
 			} else {
 				cos.headBucket({
@@ -585,7 +591,8 @@ module.exports = function(RED) {
 											} 
 
 											console.log("Cloud Object Storage Put (log): The URL is", url);
-											msg.url = url;	
+											msg.url = url;
+											node.send(msg); // burton boucher 20190625 presign url output
 										});
 
 									}
@@ -594,7 +601,10 @@ module.exports = function(RED) {
 									node.status({fill:"green",shape:"ring",text:"cos.status.ready"});
 
 									// Send the output back 
-									node.send(msg);
+									// burton boucher 20190626
+									if (!geturl){
+										node.send(msg);
+									};
 								});
 
 							});	


### PR DESCRIPTION
Get Url check box in nodes does not enable msg.url output. It appears the codes was intended to output msg.url = gurl but was missing node.send(url) to actually include in message. Also needed logic to control which of the two messages to send. With url and without. if (!geturl) ensures two messages will not send if Get url = true.

Would like to merge for a project. 