### PR TITLE
Updated HMAC url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This node was tested under Nodejs V8.x LTS and NPM 6.x on NodeRed 1.0.
 Provides a few nodes to easily manage objects within buckets of an instantce of the IBM Object Storage Service. This node uses the S3-API to communicate with the instance. 
 In order to use this nodes, you must specify the credentials from the IBM Cloud Object Storage service. 
 
-The bucket in the IBM Cloud Object Storage service must exist. When an URL to the object is needed, use HMAC credentials within the config to provide a 15 minute accessable signed URL to the object. See <a href="https://cloud.ibm.com/docs/services/cloud-object-storage?topic=cloud-object-storage-hmac" target="_new">IBM Cloud Object Storage - Using HMAC credentials</a> for more details.
+The bucket in the IBM Cloud Object Storage service must exist. When an URL to the object is needed, use HMAC credentials within the config to provide a 15 minute accessable signed URL to the object. See <a href="https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-uhc-hmac-credentials-main" target="_new">IBM Cloud Object Storage - Using HMAC credentials</a> for more details.
 
 ### COS Object Put
 


### PR DESCRIPTION
The url was broken. Updated to https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-uhc-hmac-credentials-main